### PR TITLE
Fixed spacing in header of License.txt

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-GNU GENERAL PUBLIC LICENSE
+                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
  Copyright (C) 2007 Free Software Foundation, Inc. {http://fsf.org/}


### PR DESCRIPTION
A nearly pointless commit to fix the alignment of the title in the license file, as part of the 7.x-1.7 audit.
