### PR TITLE
Checksum Cleanup

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -76,7 +76,7 @@ function islandora_checksum_admin_form(array $form, array &$form_state) {
   $form['islandora_checksum_checksum_retro_enable'] = array(
     '#type' => 'fieldset',
     '#title' => t('Apply or re-apply checksums'),
-    '#description' => t('Checksums will be applied to datastreams without checksums, or re-applied to datastreams whose checksumType does not match the site configured checksum type.'),
+    '#description' => t('Checksums will be applied to datastreams without checksums, or re-applied to datastreams whose checksumType does not match the site configured checksum type. Derivatives will be generated unless the above bypass has been enabled previously.'),
   );
   $form['islandora_checksum_checksum_retro_enable']['collection'] = array(
     '#type' => 'select',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -75,14 +75,14 @@ function islandora_checksum_admin_form(array $form, array &$form_state) {
 
   $form['islandora_checksum_checksum_retro_enable'] = array(
     '#type' => 'fieldset',
-    '#title' => t('Retroactively enable checksums'),
-    '#description' => t('Enabling checksums retroactively regenerates derivative versions for all objects in the target collection that did not previously have checksum values.'),
+    '#title' => t('Apply or re-apply checksums'),
+    '#description' => t('Checksums will be applied to datastreams without checksums, or re-applied to datastreams whose checksumType does not match the site configured checksum type.'),
   );
   $form['islandora_checksum_checksum_retro_enable']['collection'] = array(
     '#type' => 'select',
     '#title' => t('Collection'),
     '#options' => $collections,
-    '#description' => t('Select a collection to retroactively enable checksums on.'),
+    '#description' => t('Select a collection to apply or re-apply checksums on.'),
   );
   $form['islandora_checksum_checksum_retro_enable']['islandora_checksum_log_retro_errors'] = array(
     '#type' => 'checkbox',
@@ -92,7 +92,7 @@ function islandora_checksum_admin_form(array $form, array &$form_state) {
   );
   $form['islandora_checksum_checksum_retro_enable']['apply_batch'] = array(
     '#type' => 'submit',
-    '#value' => t('Enable'),
+    '#value' => t('Apply'),
     '#submit' => array('islandora_checksum_apply_retro'),
   );
   $form['islandora_checksum_checksum_retro_enable']['contact_information'] = array(

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -66,6 +66,13 @@ function islandora_checksum_admin_form(array $form, array &$form_state) {
     '#maxlength' => 255,
   );
 
+  $form['islandora_checksum_checksum_configuration']['islandora_checksum_deriv_regeneration_bypass'] = array(
+    '#title' => t('Bypass derivative regeneration when updating only checksums'),
+    '#type' => 'checkbox',
+    '#default_value' => variable_get('islandora_checksum_deriv_regeneration_bypass', FALSE),
+    '#description' => t('Note that this setting will need to be saved first before attempting to retroactively enable checksums using the controls below.'),
+  );
+
   $form['islandora_checksum_checksum_retro_enable'] = array(
     '#type' => 'fieldset',
     '#title' => t('Retroactively enable checksums'),

--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -45,7 +45,7 @@ function islandora_checksum_get_tuque_connection() {
 }
 
 /**
- * Sets the checksums for an object's datastreams.
+ * Modifies an existing object's datastream checksums.
  *
  * Does so safely, without triggering datastream hooks or derivatives.
  *
@@ -53,13 +53,13 @@ function islandora_checksum_get_tuque_connection() {
  *   The PID of the object the datastream belongs to.
  * @param array $dsids
  *   The DSIDs to set checksums for. Leave empty to use the configured defaults.
- * @param array|null $type
+ * @param string|null $type
  *   The type of checksums to set. Leave NULL to use the configured default.
  *
  * @throws InvalidArgumentException
  *   If the object doesn't exist.
  */
-function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) {
+function islandora_checksum_modify_checksums($pid, $dsids = array(), $type = NULL) {
   if (is_null($type)) {
     $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
   }
@@ -87,5 +87,28 @@ function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) 
         'checksumType' => $type,
       ));
     }
+  }
+}
+
+/**
+ * Sets the checksum definition of an object on the datastream itself.
+ *
+ * @param AbstractDatastream $datastream
+ *   The datastream to set the checksums for.
+ * @param array $dsids
+ *   An array of datastream IDs checksums are valid on. Leave empty to use the
+ *   configured defaults.
+ * @param string|null $type
+ *   The type of checksums to set. Leave NULL to use the configured default.
+ */
+function islandora_checksum_set_abstract_datastream_checksum(AbstractDatastream $datastream, $dsids = array(), $type = NULL) {
+  if (empty($dsids)) {
+    $dsids = islandora_checksum_unpack_dsid_filter();
+  }
+  if (in_array($datastream->id, $dsids)) {
+    if (is_null($type)) {
+      $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
+    }
+    $datastream->checksumType = $type;
   }
 }

--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -6,48 +6,7 @@
  */
 
 /**
- * Instantiates Tuque without the Drupal wrapper.
- *
- * When working directly with checksums, it's in our best interest to never
- * fire any hooks or generate derivatives. To prevent any issues (especially
- * race conditions resulting from the latter), we instantiate a base Tuque.
- *
- * @return RepositoryConnection
- *   A RepositoryConnection object containing a base api and repository.
- */
-function islandora_checksum_get_tuque_connection() {
-  $connection = &drupal_static(__FUNCTION__);
-  if (!$connection) {
-    // Get user info.
-    global $user;
-    if ($user->uid == 0) {
-      $user_string = 'anonymous';
-      $pass_string = 'anonymous';
-    }
-    else {
-      $user_string = $user->name;
-      $pass_string = $user->pass;
-    }
-
-    module_load_include('inc', 'islandora', 'includes/tuque');
-    try {
-      $serializer = new FedoraApiSerializer();
-      $connection = new RepositoryConnection(variable_get('islandora_base_url', 'http://localhost:8080/fedora'), $user_string, $pass_string);
-      $api = new FedoraApi($connection, $serializer);
-      $connection->repository = new FedoraRepository($api, new SimpleCache());
-    }
-    catch (Exception $e) {
-      drupal_set_message(t('Unable to connect to the repository %e', array('%e' => $e)), 'error');
-    }
-  }
-
-  return $connection;
-}
-
-/**
  * Modifies an existing object's datastream checksums.
- *
- * Does so safely, without triggering datastream hooks or derivatives.
  *
  * @param string $pid
  *   The PID of the object the datastream belongs to.
@@ -59,56 +18,24 @@ function islandora_checksum_get_tuque_connection() {
  * @throws InvalidArgumentException
  *   If the object doesn't exist.
  */
-function islandora_checksum_modify_checksums($pid, $dsids = array(), $type = NULL) {
+function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) { 
+  $object = islandora_object_load($pid);
+  if (!$object) {
+    throw new InvalidArgumentException(t('The object %id does not exist.', array(
+      '%id' => $pid,
+    )));
+  }
+
+  if (empty($dsids)) {
+    $dsids = islandora_checksum_unpack_dsid_filter();
+  }
   if (is_null($type)) {
     $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
   }
 
-  // Verify the datastream.
-  $connection = islandora_checksum_get_tuque_connection();
-  try {
-    $object = $connection->repository->getObject($pid);
-  }
-  catch (Exception $e) {
-    $message = t('Failed to load object %id.', array('%id' => $pid));
-    throw new InvalidArgumentException($message, $e->getCode(), $e);
-  }
-
-  if (empty($dsids)) {
-    $dsids = islandora_checksum_unpack_dsid_filter();
-  }
-
   foreach ($dsids as $dsid) {
-    if (isset($object[$dsid])) {
-      // Set the checksum. We're not setting this on $object[$dsid] directly
-      // because we're not guaranteed it's outside of the Islandora Tuque
-      // wrapper.
-      $connection->repository->api->m->modifyDatastream($pid, $dsid, array(
-        'checksumType' => $type,
-      ));
+    if (isset($object[$dsid]) && $object[$dsid]->checksumType) {
+      $object[$dsid]->checksumType = $type;
     }
-  }
-}
-
-/**
- * Sets the checksum definition of an object on the datastream itself.
- *
- * @param AbstractDatastream $datastream
- *   The datastream to set the checksums for.
- * @param array $dsids
- *   An array of datastream IDs checksums are valid on. Leave empty to use the
- *   configured defaults.
- * @param string|null $type
- *   The type of checksums to set. Leave NULL to use the configured default.
- */
-function islandora_checksum_set_abstract_datastream_checksum(AbstractDatastream $datastream, $dsids = array(), $type = NULL) {
-  if (empty($dsids)) {
-    $dsids = islandora_checksum_unpack_dsid_filter();
-  }
-  if (in_array($datastream->id, $dsids)) {
-    if (is_null($type)) {
-      $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
-    }
-    $datastream->checksumType = $type;
   }
 }

--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -45,67 +45,47 @@ function islandora_checksum_get_tuque_connection() {
 }
 
 /**
- * Sets the checksum for a datastream.
+ * Sets the checksums for an object's datastreams.
  *
  * Does so safely, without triggering datastream hooks or derivatives.
  *
  * @param string $pid
  *   The PID of the object the datastream belongs to.
- * @param string $dsid
- *   The DSID of the datastream to set checksums for.
- * @param string|null $type
- *   The type of checksum to set. Leave NULL to use the configured default.
+ * @param array $dsids
+ *   The DSIDs to set checksums for. Leave empty to use the configured defaults.
+ * @param array|null $type
+ *   The type of checksums to set. Leave NULL to use the configured default.
  *
  * @throws InvalidArgumentException
- *   If the PID or DSID doesn't exist, or the type is invalid.
+ *   If the object doesn't exist.
  */
-function islandora_checksum_set_checksum($pid, $dsid, $type = NULL) {
+function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) {
   if (is_null($type)) {
     $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
-  }
-  // Validate the type.
-  if (!in_array($type, islandora_checksum_valid_types())) {
-    $message = t('Invalid checksum type %type.', array('%type' => $type));
-    throw new InvalidArgumentException($message);
   }
 
   // Verify the datastream.
   $connection = islandora_checksum_get_tuque_connection();
   try {
     $object = $connection->repository->getObject($pid);
-    if (!isset($object[$dsid])) {
-      $message = t('The object %id does not contain a %dsid datastream.', array(
-        '%id' => $pid,
-        '%dsid' => $dsid,
-      ));
-      throw new InvalidArgumentException($message);
-    }
   }
   catch (Exception $e) {
     $message = t('Failed to load object %id.', array('%id' => $pid));
     throw new InvalidArgumentException($message, $e->getCode(), $e);
   }
 
-  // Set the checksum. We're not setting this on $object[$dsid] directly because
-  // we're not guaranteed it's outside of the Islandora Tuque wrapper.
-  $connection->repository->api->m->modifyDatastream($pid, $dsid, array(
-    'checksumType' => $type,
-  ));
-}
+  if (empty($dsids)) {
+    $dsids = islandora_checksum_unpack_dsid_filter();
+  }
 
-/**
- * Gets an array of valid checksum types.
- *
- * @return array
- *   An array of valid checksum types.
- */
-function islandora_checksum_valid_types() {
-  return array(
-    'DISABLED',
-    'MD5',
-    'SHA-1',
-    'SHA-256',
-    'SHA-384',
-    'SHA-512',
-  );
+  foreach ($dsids as $dsid) {
+    if (isset($object[$dsid])) {
+      // Set the checksum. We're not setting this on $object[$dsid] directly
+      // because we're not guaranteed it's outside of the Islandora Tuque
+      // wrapper.
+      $connection->repository->api->m->modifyDatastream($pid, $dsid, array(
+        'checksumType' => $type,
+      ));
+    }
+  }
 }

--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -34,7 +34,7 @@ function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) 
   }
 
   foreach ($dsids as $dsid) {
-    if (isset($object[$dsid]) && $object[$dsid]->checksumType) {
+    if (isset($object[$dsid]) && $object[$dsid]->checksumType != $type) {
       $object[$dsid]->checksumType = $type;
     }
   }

--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -18,7 +18,7 @@
  * @throws InvalidArgumentException
  *   If the object doesn't exist.
  */
-function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) { 
+function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) {
   $object = islandora_object_load($pid);
   if (!$object) {
     throw new InvalidArgumentException(t('The object %id does not exist.', array(

--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -1,0 +1,111 @@
+<?php
+
+/**
+ * @file
+ * Functionality for working with checksums in Fedora.
+ */
+
+/**
+ * Instantiates Tuque without the Drupal wrapper.
+ *
+ * When working directly with checksums, it's in our best interest to never
+ * fire any hooks or generate derivatives. To prevent any issues (especially
+ * race conditions resulting from the latter), we instantiate a base Tuque.
+ *
+ * @return RepositoryConnection
+ *   A RepositoryConnection object containing a base api and repository.
+ */
+function islandora_checksum_get_tuque_connection() {
+  $connection = &drupal_static(__FUNCTION__);
+  if (!$connection) {
+    // Get user info.
+    global $user;
+    if ($user->uid == 0) {
+      $user_string = 'anonymous';
+      $pass_string = 'anonymous';
+    }
+    else {
+      $user_string = $user->name;
+      $pass_string = $user->pass;
+    }
+
+    module_load_include('inc', 'islandora', 'includes/tuque');
+    try {
+      $serializer = new FedoraApiSerializer();
+      $connection = new RepositoryConnection(variable_get('islandora_base_url', 'http://localhost:8080/fedora'), $user_string, $pass_string);
+      $api = new FedoraApi($connection, $serializer);
+      $connection->repository = new FedoraRepository($api, new SimpleCache());
+    }
+    catch (Exception $e) {
+      drupal_set_message(t('Unable to connect to the repository %e', array('%e' => $e)), 'error');
+    }
+  }
+
+  return $connection;
+}
+
+/**
+ * Sets the checksum for a datastream.
+ *
+ * Does so safely, without triggering datastream hooks or derivatives.
+ *
+ * @param string $pid
+ *   The PID of the object the datastream belongs to.
+ * @param string $dsid
+ *   The DSID of the datastream to set checksums for.
+ * @param string|null $type
+ *   The type of checksum to set. Leave NULL to use the configured default.
+ *
+ * @throws InvalidArgumentException
+ *   If the PID or DSID doesn't exist, or the type is invalid.
+ */
+function islandora_checksum_set_checksum($pid, $dsid, $type = NULL) {
+  if (is_null($type)) {
+    $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
+  }
+  // Validate the type.
+  if (!in_array($type, islandora_checksum_valid_types())) {
+    $message = t('Invalid checksum type %type.', array('%type' => $type));
+    throw new InvalidArgumentException($message);
+  }
+
+  // Verify the datastream.
+  $connection = islandora_checksum_get_tuque_connection();
+  try {
+    $object = $connection->repository->getObject($pid);
+    if (!isset($object[$dsid])) {
+      $message = t('The object %id does not contain a %dsid datastream.', array(
+        '%id' => $pid,
+        '%dsid' => $dsid,
+      ));
+      throw new InvalidArgumentException($message);
+    }
+  }
+  catch (Exception $e) {
+    $message = t('Failed to load object %id.', array('%id' => $pid));
+    throw new InvalidArgumentException($message, $e->getCode(), $e);
+  }
+
+  // Set the checksum. We're not setting this on $object[$dsid] directly because
+  // we're not guaranteed it's outside of the Islandora Tuque wrapper.
+  $connection->repository->api->m->modifyDatastream($pid, $dsid, array(
+    'checksumType' => $type,
+  ));
+}
+
+/**
+ * Gets an array of valid checksum types.
+ *
+ * @return array
+ *   An array of valid checksum types.
+ */
+function islandora_checksum_valid_types() {
+  return array(
+    'DISABLED',
+    'MD5',
+    'SHA-1',
+    'SHA-256',
+    'SHA-384',
+    'SHA-512',
+  );
+}

--- a/islandora_checksum.drush.inc
+++ b/islandora_checksum.drush.inc
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @file
+ * Drush command for enabling checksums.
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function islandora_checksum_drush_command() {
+  return array(
+    'islandora-checksum-update-checksums' => array(
+      'aliases' => array('icuc'),
+      'description' => dt('Updates the checksumType setting for datastreams of objects in the given collection.'),
+      'drupal dependencies' => array(
+        'islandora_checksum',
+      ),
+      'options' => array(
+        'collections' => array(
+          'description' => dt('A comma-separated list of collection PIDs to update checksums in.'),
+          'required' => TRUE,
+        ),
+        'dsids' => array(
+          'description' => dt('A comma-separated list of DSIDs to update on the given collection. Omit to use the default configured ones.'),
+          'required' => FALSE,
+        ),
+        'checksum' => array(
+          'description' => dt('The checksum configuration to apply to the datastreams found. Omit to use the default configured value. Valid options are DISABLED, MD5, SHA-1, SHA-256, SHA-384, and SHA-512.'),
+          'required' => FALSE,
+        ),
+        'limit' => array(
+          'description' => dt('The number of checksums to apply in each iteration of the batches. Defaults to 10.'),
+          'required' => FALSE,
+        ),
+      ),
+      'examples' => array(
+        'Update basic image checksums to SHA-512' => 'drush islandora-checksum-update-checksums --collection=islandora:sp_basic_image_collection --checksum=SHA-512',
+      ),
+    ),
+  );
+}
+
+/**
+ * Sets the batch for updating checksums.
+ */
+function drush_islandora_checksum_update_checksums() {
+  $collection_pids = explode(',', trim(drush_get_option('collections')));
+  $dsids = drush_get_option('dsids', array());
+  if (!is_array($dsids)) {
+    $dsids = explode(',', trim($dsids));
+  }
+  $limit = drush_get_option('limit', 10);
+  $batch = FALSE;
+  foreach ($collection_pids as $collection_pid) {
+    $collection = islandora_object_load($collection_pid);
+    if (!$collection) {
+      drush_print(dt('No such collection !id; skipping ...', array(
+        '!id' => $collection_pid,
+      )));
+    }
+    else {
+      batch_set(islandora_checksum_get_collection_checksum_update_batch($collection_pid, $limit, $dsids));
+      $batch = TRUE;
+    }
+  }
+  if ($batch) {
+    drush_backend_batch_process();
+  }
+}

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -147,7 +147,7 @@ EOF;
  */
 function islandora_checksum_get_collection_members($pid, $limit = 10, $slice_params = array()) {
   module_load_include('inc', 'islandora', 'includes/utilities');
-  $message = islandora_deprecated('7.x-1.8', t('Code should be updated to use islandora_checksum_get_collection_member_details(), which provides both the PID and createdDate of objects so that accurate slicing of member sets can be perfoemd.'));
+  $message = islandora_deprecated('7.x-1.8', t('Code should be updated to use islandora_checksum_get_collection_member_details(), which provides both the PID and createdDate of objects so that accurate slicing of member sets can be performed.'));
   trigger_error(filter_xss($message), E_USER_DEPRECATED);
   $results = islandora_checksum_get_collection_member_details($pid, FALSE, $limit, $slice_params);
   $members = array();

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -34,6 +34,23 @@ function islandora_checksum_islandora_datastream_alter(AbstractObject $object, A
 }
 
 /**
+ * Implements hook_islandora_derivative_alter().
+ */
+function islandora_checksum_islandora_derivative_alter(&$derivatives, AbstractObject $object, $ds_modified_params) {
+  if (!empty($ds_modified_params) && variable_get('islandora_checksum_deriv_regeneration_bypass', FALSE)) {
+    // When only the checksumType is modified, we don't want to trigger
+    // derivative regeneration.
+    $diff = array_diff_key($ds_modified_params, array(
+      'checksumType' => NULL,
+      'dateLastModified' => NULL,
+    ));
+    if (empty($diff)) {
+      $derivatives = array();
+    }
+  }
+}
+
+/**
  * Query the resource index to get a list of collections.
  *
  * @return array
@@ -91,12 +108,17 @@ WHERE {
     ?issue <fedora-rels-ext:isMemberOf> ?newspaper .
     ?newspaper <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   }
-}
 EOF;
   if ($slice_params) {
     $ri_query .= <<<EOF
-FILTER(?date > '{$slice_params['offset_date']}'^^xs:dateTime || (?date = '{$slice_params['offset_date']}'^^xs:dateTime && xs:string(?object) > xs:string('info:fedora/{$slice_params['offset_pid']}')))
+  FILTER(?date > '{$slice_params['offset_date']}'^^xs:dateTime || (?date = '{$slice_params['offset_date']}'^^xs:dateTime && xs:string(?object) > xs:string('info:fedora/{$slice_params['offset_pid']}')))
+}
 ORDER BY ASC(?date) ASC(?object)
+EOF;
+  }
+  else {
+    $ri_query .= <<<EOF
+}
 EOF;
   }
   if ($count) {
@@ -171,6 +193,9 @@ function islandora_checksum_get_collection_checksum_update_batch($collection_pid
     ),
     'title' => 'Enabling checksums',
     'finished' => 'islandora_checksum_batch_finished',
+    'init_message' => t('Getting objects to checksum ...'),
+    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining: @estimate.'),
+    'error_message' => t('An error occurred and not all checksums were set.'),
   );
 }
 
@@ -240,11 +265,12 @@ function islandora_checksum_enable_object_checksums($collection, $limit, $dsids,
       'offset_date' => $member['date']['value'],
     );
     $context['results'][] = $member['object']['value'];
-    $context['message'] = t('Set checksums for %id', array(
-      '%id' => $member['object']['value'],
-    ));
   }
 
+  $context['message'] = t('Set checksums for @current/@total objects.', array(
+    '@current' => $sandbox['current'],
+    '@total' => $sandbox['total'],
+  ));
   $context['finished'] = $sandbox['current'] / $sandbox['total'];
 }
 

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -25,36 +25,22 @@ function islandora_checksum_menu() {
 }
 
 /**
- * Apply checksums to datastreams using the module config.
- *
- * This also means a checksum may not be applied if the config defines it
- * should not be.
- *
- * @param AbstractObject $object
- *   A Fedora object.
- * @param AbstractDatastream $datastream
- *   A datastream on that object.
+ * Implements hook_islandora_datastream_alter().
  */
-function islandora_checksum_apply_checksum_with_config(AbstractObject $object, AbstractDatastream $datastream) {
+function islandora_checksum_islandora_datastream_alter(AbstractObject $object, AbstractDatastream $datastream, &$context) {
   if (variable_get('islandora_checksum_enable_checksum', FALSE) && islandora_checksum_dsid_is_in_filter($datastream->id)) {
-    $checksum_type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
-    module_load_include('inc', 'islandora_checksum', 'includes/checksum');
-    islandora_checksum_set_checksums($object->id, array($datastream->id), $checksum_type);
+    switch ($context['action']) {
+      case 'ingest':
+        module_load_include('inc', 'islandora_checksum', 'includes/checksum');
+        islandora_checksum_set_abstract_datastream_checksum($datastream, array(), variable_get('islandora_checksum_checksum_type', 'DISABLED'));
+        break;
+
+      case 'modify':
+        module_load_include('inc', 'islandora_checksum', 'includes/checksum');
+        islandora_checksum_modify_checksums($object->id, array($datastream->id), variable_get('islandora_checksum_checksum_type', 'DISABLED'));
+        break;
+    }
   }
-}
-
-/**
- * Implements hook_islandora_datastream_ingested().
- */
-function islandora_checksum_islandora_datastream_ingested(AbstractObject $object, AbstractDatastream $datastream) {
-  islandora_checksum_apply_checksum_with_config($object, $datastream);
-}
-
-/**
- * Implements hook_islandora_datastream_modified().
- */
-function islandora_checksum_islandora_datastream_modified(AbstractObject $object, AbstractDatastream $datastream) {
-  islandora_checksum_apply_checksum_with_config($object, $datastream);
 }
 
 /**
@@ -252,7 +238,7 @@ function islandora_checksum_enable_object_checksums($collection, $limit, $dsids,
 
   $slice = islandora_checksum_get_collection_member_details($collection, FALSE, $limit, $sandbox['offset_params']);
   foreach ($slice as $member) {
-    islandora_checksum_set_checksums($member['object']['value'], $dsids, $checksum_type);
+    islandora_checksum_modify_checksums($member['object']['value'], $dsids, $sandbox['checksum_type']);
     $sandbox['current']++;
     $sandbox['offset_params'] = array(
       'offset_pid' => $member['object']['value'],

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -28,18 +28,8 @@ function islandora_checksum_menu() {
  * Implements hook_islandora_datastream_alter().
  */
 function islandora_checksum_islandora_datastream_alter(AbstractObject $object, AbstractDatastream $datastream, &$context) {
-  if (variable_get('islandora_checksum_enable_checksum', FALSE) && islandora_checksum_dsid_is_in_filter($datastream->id)) {
-    switch ($context['action']) {
-      case 'ingest':
-      case 'modify':
-        $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
-        if ($datastream->checksumType !== $type) {
-          module_load_include('inc', 'islandora_checksum', 'includes/checksum');
-          $datastream->checksumType = variable_get('islandora_checksum_checksum_type', 'DISABLED');
-        }
-        break;
-
-    }
+  if ($context['action'] == 'ingest' && variable_get('islandora_checksum_enable_checksum', FALSE) && islandora_checksum_dsid_is_in_filter($datastream->id)) {
+    $datastream->checksumType = variable_get('islandora_checksum_checksum_type', 'DISABLED');
   }
 }
 
@@ -231,6 +221,11 @@ function islandora_checksum_enable_object_checksums($collection, $limit, $dsids,
   module_load_include('inc', 'islandora_checksum', 'includes/checksum');
   if (empty($sandbox)) {
     $sandbox['total'] = islandora_checksum_get_collection_member_details($collection, TRUE);
+    if ($sandbox['total'] == 0) {
+      $context['message'] = t('No objects to apply checksums to.');
+      $context['finished'] = 1;
+      return;
+    }
     $sandbox['current'] = 0;
     $sandbox['offset_params'] = NULL;
     $sandbox['checksum_type'] = variable_get('islandora_checksum_checksum_type', 'DISABLED');

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -43,6 +43,7 @@ function islandora_checksum_islandora_derivative_alter(&$derivatives, AbstractOb
     $diff = array_diff_key($ds_modified_params, array(
       'checksumType' => NULL,
       'dateLastModified' => NULL,
+      'dsid' => NULL,
     ));
     if (empty($diff)) {
       $derivatives = array();

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -70,9 +70,6 @@ function islandora_checksum_get_collections() {
 SELECT ?object ?label
 FROM <#ri>
 WHERE {
-:x
-
-
           <fedora-model:label> ?label
 }
 ORDER BY ?label

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -39,7 +39,7 @@ function islandora_checksum_apply_checksum_with_config(AbstractObject $object, A
   if (variable_get('islandora_checksum_enable_checksum', FALSE) && islandora_checksum_dsid_is_in_filter($datastream->id)) {
     $checksum_type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
     module_load_include('inc', 'islandora_checksum', 'includes/checksum');
-    islandora_checksum_set_checksum($object->id, $datastream->id, $checksum_type);
+    islandora_checksum_set_checksums($object->id, array($datastream->id), $checksum_type);
   }
 }
 
@@ -64,40 +64,32 @@ function islandora_checksum_islandora_datastream_modified(AbstractObject $object
  *   List of collection PIDs.
  */
 function islandora_checksum_get_collections() {
-  // Query the rindex to get all collections.
-  $tuque = islandora_get_tuque_connection();
-  $ri_query = <<<EOQ
-SELECT ?object ?label
-FROM <#ri>
-WHERE {
-          <fedora-model:label> ?label
-}
-ORDER BY ?label
-EOQ;
-  $results = $tuque->repository->ri->sparqlQuery($ri_query, 'unlimited');
-  $collections = array();
-  foreach ($results as $member) {
-    $pid = preg_replace('/info:fedora\//', '', $member['object']['value']);
-    $label = $member['label']['value'];
-    // We don't want the root collection.
-    if ($pid != 'islandora:root') {
-      $collections[$pid] = $label;
-    }
-  }
-  return $collections;
+  module_load_include('inc', 'islandora_basic_collection', 'includes/utilities');
+  $root = islandora_object_load(variable_get('islandora_repository_pid', 'islandora:root'));
+  return islandora_basic_collection_get_other_collections_as_form_options($root);
 }
 
 /**
- * Query the RI index to get PIDs of all child objects in a collection.
+ * Query the RI index for collection member details.
  *
  * @param string $pid
  *   The PID of Islandora collection.
+ * @param bool $count
+ *   Whether this is a countQuery or not.
+ * @param int $limit
+ *   The number of items to return.
+ * @param array $slice_params
+ *   An optional associative array of parameters to pass in to properly grab
+ *   the slice, including:
+ *   - 'offset_date': an ISO8601 date to filter items before
+ *   - 'offset_pid': a PID to filter items before if dates match.
  *
  * @return array
- *   List of member object PIDs.
+ *   Associative array of RI results, containg the 'object' as the object PID,
+ *   and the 'date' as the object's createdDate.
  */
-function islandora_checksum_get_collection_members($pid) {
-  // List of objects to create Bags for.
+function islandora_checksum_get_collection_member_details($pid, $count = FALSE, $limit = 10, $slice_params = array()) {
+  // List of objects to create checksums for.
   $members = array();
   // Query the rindex to get all the objects that have a 'isMemberOfCollection'
   // relationship with the specified collection and add all their PIDs to the
@@ -105,9 +97,13 @@ function islandora_checksum_get_collection_members($pid) {
   $tuque = islandora_get_tuque_connection();
   $islandora_rels_ext = ISLANDORA_RELS_EXT_URI;
   $ri_query = <<<EOF
-select ?object from <#ri> where {
+PREFIX xs: <xml-schema:>
+SELECT DISTINCT ?object ?date
+FROM <#ri>
+WHERE {
   {
     ?object <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
+    ?object <fedora-model:createdDate> ?date .
   } UNION {
     ?object <{$islandora_rels_ext}isPageOf> ?book .
     ?book <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
@@ -119,13 +115,44 @@ select ?object from <#ri> where {
     ?issue <fedora-rels-ext:isMemberOf> ?newspaper .
     ?newspaper <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   }
-
 }
 EOF;
-  $result = $tuque->repository->ri->sparqlQuery($ri_query, 'unlimited');
-  foreach ($result as $member) {
-    $member_pid = preg_replace('/info:fedora\//', '', $member['object']['value']);
-    $members[] = $member_pid;
+  if ($slice_params) {
+    $ri_query .= <<<EOF
+FILTER(?date > '{$slice_params['offset_date']}'^^xs:dateTime || (?date = '{$slice_params['offset_date']}'^^xs:dateTime && xs:string(?object) > xs:string('info:fedora/{$slice_params['offset_pid']}')))
+ORDER BY ASC(?date) ASC(?object)
+EOF;
+  }
+  if ($count) {
+    return $tuque->repository->ri->countQuery($ri_query, 'sparql');
+  }
+  return $tuque->repository->ri->sparqlQuery($ri_query, $limit);
+}
+
+/**
+ * Query the RI index to get PIDs of all child objects in a collection.
+ *
+ * @param string $pid
+ *   The PID of Islandora collection.
+ * @param int $limit
+ *   The number of items to return.
+ * @param array $slice_params
+ *   An optional associative array of parameters to pass in to properly grab
+ *   the slice, including:
+ *   - 'offset_date': an ISO8601 date to filter items before
+ *   - 'offset_pid': a PID to filter items before if dates match.
+ *
+ * @return array
+ *   List of member object PIDs.
+ */
+function islandora_checksum_get_collection_members($pid, $limit = 10, $slice_params = array()) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $message = islandora_deprecated('7.x-1.8', t('Code should be updated to use islandora_checksum_get_collection_member_details(), which provides both the PID and createdDate of objects so that accurate slicing of member sets can be perfoemd.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
+  $results = islandora_checksum_get_collection_member_details($pid, FALSE, $limit, $slice_params);
+  $members = array();
+  foreach ($results as $result) {
+    $members[] = $member['object']['value'];
   }
   return $members;
 }
@@ -134,8 +161,43 @@ EOF;
  * Custom button submit handler.
  */
 function islandora_checksum_apply_retro($form, &$form_state) {
-  batch_set(islandora_checksum_enable_retro_checksums($form_state['values']['collection']));
+  batch_set(islandora_checksum_get_collection_checksum_update_batch($form_state['values']['collection']));
 }
+
+/**
+ * Gets the batch definition for enabling or re-applying checksums.
+ *
+ * @param string $collection_pid
+ *   The PID of the collection to apply checksums to.
+ * @param int $limit
+ *   The number of items to do per-batch.
+ * @param array $dsids
+ *   The DSIDs to apply checksums to. Leave empty to use the default
+ *   configuration.
+ *
+ * @return array
+ *   The batch definition.
+ */
+function islandora_checksum_get_collection_checksum_update_batch($collection_pid, $limit = 10, $dsids = array()) {
+  if (empty($dsids)) {
+    $dsids = islandora_checksum_unpack_dsid_filter();
+  }
+  return array(
+    'operations' => array(
+      array(
+        'islandora_checksum_enable_object_checksums',
+        array(
+          $collection_pid,
+          $limit,
+          $dsids,
+        ),
+      ),
+    ),
+    'title' => 'Enabling checksums',
+    'finished' => 'islandora_checksum_batch_finished',
+  );
+}
+
 
 /**
  * Sets up the batch.
@@ -147,6 +209,9 @@ function islandora_checksum_apply_retro($form, &$form_state) {
  *   The batch.
  */
 function islandora_checksum_enable_retro_checksums($collection_pid) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+  $message = islandora_deprecated('7.x-1.8', t('As this function relies on getting every member of a collection to build the batch, it can time out or run out of memory when attempting to do so on exceptionally large collections. Code should be changed to use islandora_checksum_get_collection_checksum_update_batch(), which instead does a single batch operation that iterates over object sets.'));
+  trigger_error(filter_xss($message), E_USER_DEPRECATED);
   $pids = islandora_checksum_get_collection_members($collection_pid);
   $operations = array();
   $num_objects = count($pids);
@@ -164,41 +229,42 @@ function islandora_checksum_enable_retro_checksums($collection_pid) {
 }
 
 /**
- * Process a single object in the batch.
+ * Batch process to enable checksums for a collection's children.
  *
- * @param string $pid
- *   The PID of the object.
+ * @param string $collection
+ *   The PID of the collection.
+ * @param int $limit
+ *   The number of items to do per-iteration.
+ * @param array $dsids
+ *   The datastream DSIDs to target.
+ * @param array $context
+ *   The batch context.
  */
-function islandora_checksum_enable_object_checksums($pid, $num_objects, &$context) {
-  $object = islandora_object_load($pid);
-  $context['results'][] = $pid;
-  $context['message'] = t('Process object "@pid"', array('@pid' => $pid)) . ' ' . $num_objects;
-  $tuque = islandora_get_tuque_connection();
-  $datastreams_to_check = islandora_checksum_unpack_dsid_filter();
-  foreach ($object as $ds) {
-    if (islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $ds) && $ds->checksumType == 'DISABLED' &&
-    (count($datastreams_to_check) == 0 || in_array($ds->id, $datastreams_to_check))) {
-      $ds->checksumType = variable_get('islandora_checksum_checksum_type', 'DISABLED');
-      // Calling modifyDatastream triggers
-      // islandora_checksum_islandora_datastream_alter(),
-      // enabling the checksum.
-      try {
-        $ds_info = $tuque->api->m->modifyDatastream($pid, $ds->id);
-      }
-      catch (RepositoryException $e) {
-        if (variable_get('islandora_checksum_log_retro_errors', 1)) {
-          watchdog('islandora_checksum', 'Checksum for !object, !ds_id not enabled: !message',
-            array(
-              '!object' => $pid,
-              '!ds_id' => $ds->id,
-              '!message' => $e->getMessage(),
-            ),
-            WATCHDOG_WARNING
-          );
-        }
-      }
-    }
+function islandora_checksum_enable_object_checksums($collection, $limit, $dsids, &$context) {
+  $sandbox = &$context['sandbox'];
+  module_load_include('inc', 'islandora_checksum', 'includes/checksum');
+  if (empty($sandbox)) {
+    $sandbox['total'] = islandora_checksum_get_collection_member_details($collection, TRUE);
+    $sandbox['current'] = 0;
+    $sandbox['offset_params'] = NULL;
+    $sandbox['checksum_type'] = variable_get('islandora_checksum_checksum_type', 'DISABLED');
   }
+
+  $slice = islandora_checksum_get_collection_member_details($collection, FALSE, $limit, $sandbox['offset_params']);
+  foreach ($slice as $member) {
+    islandora_checksum_set_checksums($member['object']['value'], $dsids, $checksum_type);
+    $sandbox['current']++;
+    $sandbox['offset_params'] = array(
+      'offset_pid' => $member['object']['value'],
+      'offset_date' => $member['date']['value'],
+    );
+    $context['results'][] = $member['object']['value'];
+    $context['message'] = t('Set checksums for %id', array(
+      '%id' => $member['object']['value'],
+    ));
+  }
+
+  $context['finished'] = $sandbox['current'] / $sandbox['total'];
 }
 
 /**

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -223,12 +223,10 @@ function islandora_checksum_enable_retro_checksums($collection_pid) {
  *   The number of items to do per-iteration.
  * @param array $dsids
  *   The datastream DSIDs to target.
- * @param bool $fire_hooks
- *   Whether or not to 
  * @param array $context
  *   The batch context.
  */
-function islandora_checksum_enable_object_checksums($collection, $limit, $dsids, $fire_hooks = TRUE, &$context) {
+function islandora_checksum_enable_object_checksums($collection, $limit, $dsids, &$context) {
   $sandbox = &$context['sandbox'];
   module_load_include('inc', 'islandora_checksum', 'includes/checksum');
   if (empty($sandbox)) {

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -301,7 +301,7 @@ function islandora_checksum_batch_finished($success, $results, $operations) {
  */
 function islandora_checksum_unpack_dsid_filter() {
   $datastreams_to_check = &drupal_static(__FUNCTION__);
-  if (!$datastreams_to_check) {
+  if (is_null($datastreams_to_check)) {
     if (strlen(variable_get('islandora_checksum_dsids_to_check', ''))) {
       $datastreams_to_check = explode(',',
         variable_get('islandora_checksum_dsids_to_check', ''));

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -31,14 +31,14 @@ function islandora_checksum_islandora_datastream_alter(AbstractObject $object, A
   if (variable_get('islandora_checksum_enable_checksum', FALSE) && islandora_checksum_dsid_is_in_filter($datastream->id)) {
     switch ($context['action']) {
       case 'ingest':
-        module_load_include('inc', 'islandora_checksum', 'includes/checksum');
-        islandora_checksum_set_abstract_datastream_checksum($datastream, array(), variable_get('islandora_checksum_checksum_type', 'DISABLED'));
+      case 'modify':
+        $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
+        if ($datastream->checksumType !== $type) {
+          module_load_include('inc', 'islandora_checksum', 'includes/checksum');
+          $datastream->checksumType = variable_get('islandora_checksum_checksum_type', 'DISABLED');
+        }
         break;
 
-      case 'modify':
-        module_load_include('inc', 'islandora_checksum', 'includes/checksum');
-        islandora_checksum_modify_checksums($object->id, array($datastream->id), variable_get('islandora_checksum_checksum_type', 'DISABLED'));
-        break;
     }
   }
 }
@@ -223,10 +223,12 @@ function islandora_checksum_enable_retro_checksums($collection_pid) {
  *   The number of items to do per-iteration.
  * @param array $dsids
  *   The datastream DSIDs to target.
+ * @param bool $fire_hooks
+ *   Whether or not to 
  * @param array $context
  *   The batch context.
  */
-function islandora_checksum_enable_object_checksums($collection, $limit, $dsids, &$context) {
+function islandora_checksum_enable_object_checksums($collection, $limit, $dsids, $fire_hooks = TRUE, &$context) {
   $sandbox = &$context['sandbox'];
   module_load_include('inc', 'islandora_checksum', 'includes/checksum');
   if (empty($sandbox)) {
@@ -238,7 +240,7 @@ function islandora_checksum_enable_object_checksums($collection, $limit, $dsids,
 
   $slice = islandora_checksum_get_collection_member_details($collection, FALSE, $limit, $sandbox['offset_params']);
   foreach ($slice as $member) {
-    islandora_checksum_modify_checksums($member['object']['value'], $dsids, $sandbox['checksum_type']);
+    islandora_checksum_set_checksums($member['object']['value'], $dsids, $sandbox['checksum_type']);
     $sandbox['current']++;
     $sandbox['offset_params'] = array(
       'offset_pid' => $member['object']['value'],

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -25,22 +25,36 @@ function islandora_checksum_menu() {
 }
 
 /**
- * Implements hook_islandora_datastream_alter().
+ * Apply checksums to datastreams using the module config.
+ *
+ * This also means a checksum may not be applied if the config defines it
+ * should not be.
+ *
+ * @param AbstractObject $object
+ *   A Fedora object.
+ * @param AbstractDatastream $datastream
+ *   A datastream on that object.
  */
-function islandora_checksum_islandora_datastream_alter(AbstractObject &$object, AbstractDatastream &$datastream, &$context) {
-  $checksum_type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
-  $datastreams_to_check = islandora_checksum_unpack_dsid_filter();
-  if (variable_get('islandora_checksum_enable_checksum', FALSE) &&
-    in_array($context['action'], array('ingest', 'modify')) &&
-    !($datastream->checksumType == $checksum_type || (isset($context['params']['checksumType']) && $context['params']['checksumType'] == $checksum_type)) &&
-    (count($datastreams_to_check) == 0 || in_array($datastream->id, $datastreams_to_check))) {
-    if ($context['action'] == 'ingest') {
-      $datastream->checksumType = $checksum_type;
-    }
-    elseif ($context['action'] == 'modify') {
-      $context['params']['checksumType'] = $checksum_type;
-    }
+function islandora_checksum_apply_checksum_with_config(AbstractObject $object, AbstractDatastream $datastream) {
+  if (variable_get('islandora_checksum_enable_checksum', FALSE) && islandora_checksum_dsid_is_in_filter($datastream->id)) {
+    $checksum_type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
+    module_load_include('inc', 'islandora_checksum', 'includes/checksum');
+    islandora_checksum_set_checksum($object->id, $datastream->id, $checksum_type);
   }
+}
+
+/**
+ * Implements hook_islandora_datastream_ingested().
+ */
+function islandora_checksum_islandora_datastream_ingested(AbstractObject $object, AbstractDatastream $datastream) {
+  islandora_checksum_apply_checksum_with_config($object, $datastream);
+}
+
+/**
+ * Implements hook_islandora_datastream_modified().
+ */
+function islandora_checksum_islandora_datastream_modified(AbstractObject $object, AbstractDatastream $datastream) {
+  islandora_checksum_apply_checksum_with_config($object, $datastream);
 }
 
 /**
@@ -56,7 +70,9 @@ function islandora_checksum_get_collections() {
 SELECT ?object ?label
 FROM <#ri>
 WHERE {
-  ?object <fedora-model:hasModel> <info:fedora/islandora:collectionCModel> ;
+:x
+
+
           <fedora-model:label> ?label
 }
 ORDER BY ?label
@@ -214,17 +230,34 @@ function islandora_checksum_batch_finished($success, $results, $operations) {
  *   Array of DSIDs, if not empty then only these DSIDs will get checksums.
  */
 function islandora_checksum_unpack_dsid_filter() {
-  if (strlen(variable_get('islandora_checksum_dsids_to_check', ''))) {
-    $datastreams_to_check = explode(',',
-      variable_get('islandora_checksum_dsids_to_check', ''));
-  }
-  else {
-    $datastreams_to_check = array();
-  }
-  // Make sure there are no spaces around the DSIDs, so we can get a
-  // match in in_array().
-  foreach ($datastreams_to_check as &$dsid) {
-    $dsid = trim($dsid);
+  $datastreams_to_check = &drupal_static(__FUNCTION__);
+  if (!$datastreams_to_check) {
+    if (strlen(variable_get('islandora_checksum_dsids_to_check', ''))) {
+      $datastreams_to_check = explode(',',
+        variable_get('islandora_checksum_dsids_to_check', ''));
+    }
+    else {
+      $datastreams_to_check = array();
+    }
+    // Make sure there are no spaces around the DSIDs, so we can get a
+    // match in in_array().
+    foreach ($datastreams_to_check as &$dsid) {
+      $dsid = trim($dsid);
+    }
   }
   return $datastreams_to_check;
+}
+
+/**
+ * Checks if a DSID is in the DSID filter.
+ *
+ * @param string $dsid
+ *   The DSID to check.
+ *
+ * @return bool
+ *   Whether or not the DSID was in the filter.
+ */
+function islandora_checksum_dsid_is_in_filter($dsid) {
+  $filter = islandora_checksum_unpack_dsid_filter();
+  return in_array($dsid, $filter);
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1660 for duplicate versions, and https://jira.duraspace.org/browse/ISLANDORA-1751 for fixing PHP timeout/memory issues
# What does this Pull Request do?

Some general cleanup to make sure that checksum generation and application can be done smoothly without unexpected hiccups. Details are below.
# What's new?
- Importantly, setting the checksum on a datastream is no longer done through the Islandora Tuque wrapper, but rather is done directly through Tuque itself. This bypasses any issues we may run into with hooks being fired as a result of ingesting or modifying a datastream.
- The query to get collection members now also gets the createdDate of those members so that the checksum application batch can be accurately sliced while it's in-progress.
- In conjunction with this, the query that only returns the PID has been deprecated, to prevent people from running a batch that may be inaccurately sliced.
- A batch definition has been created that runs a single operation which iterates through chunks of items to generate checksums on.
- In conjunction with this, the batch definition that gathers all members before returning the definition has been deprecated, as this function can time out.
- A drush command has been created to handle batch application of checksums, to make use of Drush's batch magic.
# How should this be tested?

Pretty much every part of checksum has been touched here, so a full module run-through would be necessary. This includes:
- Making sure checksums are applied appropriately when creating new datastreams
- Making sure checksums are applied appropriately when datastreams are updated
- Making sure checksums don't appear where they shouldn't
- Making sure the retroactive batch applicator for collection checksums works, both through the UI and using the new Drush command
# Additional Notes:

Mentioned above, but bears repeating - this touches https://jira.duraspace.org/browse/ISLANDORA-1660 and https://jira.duraspace.org/browse/ISLANDORA-1751, as these are technically two separate issues, but ISLANDORA-1660 should be considered necessary for ISLANDORA-1751, as it impacts execution time.
# Interested parties

This module currently needs a maintainer ... Don Richards initially submitted ISLANDORA-1660, but I don't see him on GitHub, so imma just tag @Islandora/7-x-1-x-committers - hopefully that's okay.
