### PR TITLE
Address ISLANDORA-1809.

### DIFF
--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -330,5 +330,10 @@ function islandora_checksum_unpack_dsid_filter() {
  */
 function islandora_checksum_dsid_is_in_filter($dsid) {
   $filter = islandora_checksum_unpack_dsid_filter();
-  return in_array($dsid, $filter);
+  if (count($filter) === 0) {
+    return TRUE;
+  }
+  else {
+    return in_array($dsid, $filter);
+  }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1809
# What does this Pull Request do?

Fixes issue with "Datastreams to Checksum" option. This PR adds logic so that if no DSIDs are listed in that config option, checksums for all datastreams are generated (as is the documented function of this option).
# What's new?

If "Datastreams to Checksum" is empty, all datastreams now get checksums.
# How should this be tested?
1. Enable checksums
2. Leave "Datastreams to Checksum" empty
3. Ingest object
4. In Fedora admin client, check all datastreams. They all should have a checksum.

Regression testing:
1. Enable checksums
2. Enter "OBJ,MODS" in the "Datastreams to Checksum" field
3. Ingest object
4. In Fedora admin client, check all datastreams. Only the OBJ and MODS datastreams should have a checksum.
# Additional Notes:
- Does this change require documentation to be updated? 
  No.
- Does this change add any new dependencies? 
  No.
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
  If admins left the "Datastreams to Checksum" empty while using previous versions of this module, they should verify that all their datastreams had checksums applied. If all datastreams were not getting checksums, they will need to regenerate checksums.
- Could this change impact execution of existing code?
  No.
# Interested parties

@bradspry, @Islandora/7-x-1-x-committers
