### PR TITLE
Address ISLANDORA-1809.

### DIFF
--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -8,6 +8,8 @@
 /**
  * Modifies an existing object's datastream checksums.
  *
+ * Used in the retroactive checksum generation batch.
+ *
  * @param string $pid
  *   The PID of the object the datastream belongs to.
  * @param array $dsids

--- a/includes/checksum.inc
+++ b/includes/checksum.inc
@@ -26,16 +26,16 @@ function islandora_checksum_set_checksums($pid, $dsids = array(), $type = NULL) 
     )));
   }
 
-  if (empty($dsids)) {
-    $dsids = islandora_checksum_unpack_dsid_filter();
-  }
   if (is_null($type)) {
     $type = variable_get('islandora_checksum_checksum_type', 'DISABLED');
   }
 
-  foreach ($dsids as $dsid) {
+  foreach ($object as $ds) {
+    $dsid = $ds->id;
     if (isset($object[$dsid]) && $object[$dsid]->checksumType != $type) {
-      $object[$dsid]->checksumType = $type;
+      if (islandora_checksum_dsid_is_in_filter($dsid)) {
+        $object[$dsid]->checksumType = $type;
+      }
     }
   }
 }

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -330,5 +330,10 @@ function islandora_checksum_unpack_dsid_filter() {
  */
 function islandora_checksum_dsid_is_in_filter($dsid) {
   $filter = islandora_checksum_unpack_dsid_filter();
-  return in_array($dsid, $filter);
+  if (count($filter) === 0) {
+    return TRUE;
+  }
+  else {
+    return in_array($dsid, $filter);
+  }
 }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1809
# What does this Pull Request do?

Fixes issue with "Datastreams to Checksum" option. This PR adds logic so that if no DSIDs are listed in that config option, checksums for all datastreams are generated (as is the documented function of this option).
# What's new?

If "Datastreams to Checksum" is empty, all datastreams now get checksums.
# How should this be tested?

For new objects:
1. Enable checksums
2. Leave "Datastreams to Checksum" empty
3. Ingest object
4. In Fedora admin client, check all datastreams. They all should have a checksum.

Regression testing:
1. Enable checksums
2. Enter "OBJ,MODS" in the "Datastreams to Checksum" field
3. Ingest object
4. In Fedora admin client, check all datastreams. Only the OBJ and MODS datastreams should have a checksum.

For retroactive generation of checksums:
1. Disable checksums
2. Leave "Datastreams to Checksum" empty
3. Ingest two objects into the same collection
4. In Fedora admin client, check all datastreams. None should have checksums.
5. Enable checksums
6. Enter "OBJ,MODS" in the "Datastreams to Checksum" field
7. Save the admin settings
8. In the "Collection" select list, choose the collection you ingested the objects into
9. Click on "Apply"
10. In Fedora admin client, check all datastreams for your two objects. Only the OBJ and MODS datastreams should have a checksum.

Regression testing:
1. Disable checksums
2. Leave "OBJ,MODS" in the "Datastreams to Checksum" field
3. Ingest two objects into the same collection
4. In Fedora admin client, check all datastreams the two objects. None should have checksums.
5. Enable checksums
6. Save the admin settings
7. In the "Collection" select list, choose the collection you ingested the objects into
8. Click on "Apply"
9. In Fedora admin client, check all datastreams for your two objects. Only the OBJ and MODS datastreams should have a checksum.
# Additional Notes:
- Does this change require documentation to be updated? 
  No.
- Does this change add any new dependencies? 
  No.
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
  If admins left the "Datastreams to Checksum" empty while using previous versions of this module, they should verify that all their datastreams had checksums applied. If all datastreams were not getting checksums, they will need to regenerate checksums.
- Could this change impact execution of existing code?
  No.
# Interested parties

@bradspry, @Islandora/7-x-1-x-committers
