### PR TITLE
ISLANDORA-1924 - Infinite loop creating checksums in batch

### DIFF
--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -100,12 +100,15 @@ WHERE {
     ?object <fedora-model:createdDate> ?date .
   } UNION {
     ?object <{$islandora_rels_ext}isPageOf> ?book .
+    ?object <fedora-model:createdDate> ?date .
     ?book <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   } UNION {
     ?object <fedora-rels-ext:isConstituentOf> ?compound .
+    ?object <fedora-model:createdDate> ?date .
     ?compound <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   } UNION {
     ?object <fedora-rels-ext:isMemberOf> ?issue .
+    ?object <fedora-model:createdDate> ?date .
     ?issue <fedora-rels-ext:isMemberOf> ?newspaper .
     ?newspaper <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   }

--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -97,21 +97,18 @@ FROM <#ri>
 WHERE {
   {
     ?object <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
-    ?object <fedora-model:createdDate> ?date .
   } UNION {
     ?object <{$islandora_rels_ext}isPageOf> ?book .
-    ?object <fedora-model:createdDate> ?date .
     ?book <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   } UNION {
     ?object <fedora-rels-ext:isConstituentOf> ?compound .
-    ?object <fedora-model:createdDate> ?date .
     ?compound <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   } UNION {
     ?object <fedora-rels-ext:isMemberOf> ?issue .
-    ?object <fedora-model:createdDate> ?date .
     ?issue <fedora-rels-ext:isMemberOf> ?newspaper .
     ?newspaper <fedora-rels-ext:isMemberOfCollection> <info:fedora/$pid> .
   }
+  ?object <fedora-model:createdDate> ?date .
 EOF;
   if ($slice_params) {
     $ri_query .= <<<EOF


### PR DESCRIPTION
**JIRA Ticket**: (link)

https://jira.duraspace.org/browse/ISLANDORA-1924

# What does this Pull Request do?

When running the batch to enable checksums on a collection that contains books, compound objects or newspapers the batch runs forever. It does this because we get the total number of objects to batch without a date filter, then we start running the batch slicing the objects we are batching based on date. Because the query for newspapers, books and compound objects didn't include a date, nothing is returned for them, but they are included in the total number of objects we expect, so the batch runs forever.

# What's new?

Update the SPARQL query to check for the date for all the objects.

# How should this be tested?

Create a new collection. Ingest a book into this collection. Try to enable checksums on this collection. You should see the batch run forever. 

Enable patch. Blam-o no more infinte loops.

# Additional Notes:
Any additional information that you think would be helpful when reviewing this PR.

# Interested parties
@DiegoPino @mjordan 