### PR TITLE
Matching argument defaults for islandora's derivative alter api hook

### DIFF
--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -36,7 +36,7 @@ function islandora_checksum_islandora_datastream_alter(AbstractObject $object, A
 /**
  * Implements hook_islandora_derivative_alter().
  */
-function islandora_checksum_islandora_derivative_alter(&$derivatives, AbstractObject $object, $ds_modified_params) {
+function islandora_checksum_islandora_derivative_alter(&$derivatives, AbstractObject $object = NULL, $ds_modified_params = array()) {
   if (!empty($ds_modified_params) && variable_get('islandora_checksum_deriv_regeneration_bypass', FALSE)) {
     // When only the checksumType is modified, we don't want to trigger
     // derivative regeneration.


### PR DESCRIPTION
JIRA Ticket: https://jira.duraspace.org/browse/ISLANDORA-1960
https://github.com/Islandora/islandora/pull/673

# What does this Pull Request do?

Implements actually the changes coming from the parent pull.

# What's new?
Allows this derivative alter hook to be called without an actual Islandora Object.

# How should this be tested?

Please see https://github.com/Islandora/islandora/pull/673. All info there is relevant and both are dependant.

# Additional Notes:
This is the workhorse/implementation pull request. There is an associated Please see https://github.com/Islandora/islandora/pull/673 one that is the one that allows the existance (function signature) of a NULL object argument.

Could this change impact execution of existing code? No

# Interested parties
@Islandora/7-x-1-x-committers