### PR TITLE
Add php-7.2 and php-7.3 version tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
 env:
   - FEDORA_VERSION="3.5"
   - FEDORA_VERSION="3.6.2"


### PR DESCRIPTION
# What does this Pull Request do?

- Add the `php-7.2` and `php-7.3` version tests during Travis CI build because they're stable versions.

# What's new?
- Add `php-7.2` and `php-7.3` version tests during Travis CI build.