### PR TITLE
Address ISLANDORA-2475; always sort by date and object, not just when…

### DIFF
--- a/islandora_checksum.module
+++ b/islandora_checksum.module
@@ -114,7 +114,6 @@ EOF;
     $ri_query .= <<<EOF
   FILTER(?date > '{$slice_params['offset_date']}'^^xs:dateTime || (?date = '{$slice_params['offset_date']}'^^xs:dateTime && xs:string(?object) > xs:string('info:fedora/{$slice_params['offset_pid']}')))
 }
-ORDER BY ASC(?date) ASC(?object)
 EOF;
   }
   else {
@@ -125,6 +124,10 @@ EOF;
   if ($count) {
     return $tuque->repository->ri->countQuery($ri_query, 'sparql');
   }
+  $ri_query .= <<<EOF
+
+ORDER BY ASC(?date) ASC(?object)
+EOF;
   return $tuque->repository->ri->sparqlQuery($ri_query, $limit);
 }
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2475

# What does this Pull Request do?
Always sort by date and object so first offset date is based on an ordered list.

# What's new?
Move sparql order by so they're always applied to the query regardless of slice.

# How should this be tested?
* Ingest 11 or more objects into a collection
* Apply checksums to collection via http://localhost/admin/islandora/tools/checksum
* Verify all objects receive a checksum in the collection

# Interested parties
@Islandora/7-x-1-x-committers @mjordan as maintainer